### PR TITLE
test: minor fixes

### DIFF
--- a/features/steps/generic_testapp.py
+++ b/features/steps/generic_testapp.py
@@ -11,7 +11,7 @@ class GenericTestApp(App):
 
     deployment_name_pattern = "{name}"
 
-    def __init__(self, name, namespace, app_image="ghcr.io/servicebindings/generic-test-app"):
+    def __init__(self, name, namespace, app_image="ghcr.io/servicebinding/generic-test-app"):
         App.__init__(self, name, namespace, app_image, "8080")
 
     def format_pattern(self, pattern):

--- a/resources/apps/generic-test-app/README.md
+++ b/resources/apps/generic-test-app/README.md
@@ -6,5 +6,5 @@ Build and push with
 ```shell
 docker buildx build --push \
 --platform "linux/amd64,linux/ppc64le,linux/arm64,linux/s390x" \
--t quay.io/service-binding/generic-test-app:YYYYMMDD .
+-t ghcr.io/servicebinding/generic-test-app .
 ```

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -10,10 +10,10 @@ PYTHON_VENV_DIR="${OUTPUT_DIR}/venv"
 
 mkdir -p "${OUTPUT_DIR}"
 
-TEST_NAMESPACE="cts-namespace"
+TEST_NAMESPACE="servicebindings-cts"
 TEST_ACCEPTANCE_OUTPUT_DIR="${OUTPUT_DIR}"/results
 
-if [ $(kubectl get namespace ${TEST_NAMESPACE} > /dev/null; echo $?) -ne 0 ]; then
+if [ $(kubectl get namespace ${TEST_NAMESPACE} > /dev/null; echo $?) -eq '0' ]; then
     kubectl delete namespace ${TEST_NAMESPACE}
 fi
 


### PR DESCRIPTION
This fixes some minor things that were missed in the last PR (#3):
- Remove existing references to SBO; this is a separate implementation.
- Pull from ghcr.io, not quay.io (the joys of testing)
- Change the testing namespace from the generic `cts-namespace` to the
  more specific `servicebindings-cts`
- Test for the existance of the testing namespace correctly

Signed-off-by: Andy Sadler <ansadler@redhat.com>