### PR TITLE
Provisioned service tests

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Push dependencies
       run: |
         eval $(minikube docker-env)
-        docker build -t ghcr.io/servicebindings/generic-test-app resources/apps/generic-test-app
+        docker build -t ghcr.io/servicebindings/generic-test-app:main resources/apps/generic-test-app
 
         # TODO: actually have an operator here
         kubectl apply -f .github/resources/servicebinding_crds.yaml

--- a/features/bindAppToProvisionedService.feature
+++ b/features/bindAppToProvisionedService.feature
@@ -94,6 +94,18 @@ Feature: Bind workload to provisioned service
         """
     Then Service Binding becomes ready
     And The service binding root is valid
+    And The projected binding "$scenario_id" has "username" set to
+        """
+        foo
+        """
+    And The projected binding "$scenario_id" has "password" set to
+        """
+        bar
+        """
+    And The projected binding "$scenario_id" has "type" set to
+        """
+        db
+        """
 
   Scenario: Override type in provisioned service with values from ServiceBinding
     Given The Custom Resource is present

--- a/features/bindAppToProvisionedService.feature
+++ b/features/bindAppToProvisionedService.feature
@@ -62,7 +62,7 @@ Feature: Bind workload to provisioned service
         db
         """
 
-  Scenario: Fall back to default if SERVICE_BINDING_ROOT is not set
+  Scenario: Fall back to a default if SERVICE_BINDING_ROOT is not set
     Given The Custom Resource is present
         """
         apiVersion: stable.example.com/v1
@@ -169,6 +169,99 @@ Feature: Bind workload to provisioned service
               apiVersion: apps/v1
               kind: Deployment
               name: $scenario_id
+        """
+    Then Service Binding becomes ready
+    And Content of file "/bindings/$scenario_id/username" in workload pod is
+        """
+        foo
+        """
+    And Content of file "/bindings/$scenario_id/password" in workload pod is
+        """
+        bar
+        """
+    And Content of file "/bindings/$scenario_id/type" in workload pod is
+        """
+        baz
+        """
+
+  Scenario: Override provider in provisioned service with values from ServiceBinding
+    Given The Custom Resource is present
+        """
+        apiVersion: stable.example.com/v1
+        kind: ProvisionedBackend
+        metadata:
+            name: $scenario_id
+        spec:
+            foo: bar
+        status:
+            binding:
+                name: provisioned-secret
+        """
+    And Generic test application is running
+    When Service Binding is applied
+        """
+        apiVersion: servicebinding.io/v1beta1
+        kind: ServiceBinding
+        metadata:
+            name: $scenario_id
+        spec:
+            provider: baz
+            service:
+                apiVersion: stable.example.com/v1
+                kind: ProvisionedBackend
+                name: $scenario_id
+            workload:
+                apiVersion: apps/v1
+                kind: Deployment
+                name: $scenario_id
+        """
+    Then Service Binding becomes ready
+    And Content of file "/bindings/$scenario_id/username" in workload pod is
+        """
+        foo
+        """
+    And Content of file "/bindings/$scenario_id/password" in workload pod is
+        """
+        bar
+        """
+    And Content of file "/bindings/$scenario_id/type" in workload pod is
+        """
+        db
+        """
+    And Content of file "/bindings/$scenario_id/provider" in workload pod is
+        """
+        baz
+        """
+
+  Scenario: Use SERVICE_BINDING_ROOT provided by a workload
+    Given The Custom Resource is present
+        """
+        apiVersion: stable.example.com/v1
+        kind: ProvisionedBackend
+        metadata:
+            name: $scenario_id
+        spec:
+            foo: bar
+        status:
+            binding:
+                name: provisioned-secret
+        """
+    And Generic test application is running with binding root as "/bindings/external"
+    When Service Binding is applied
+        """
+        apiVersion: servicebinding.io/v1beta1
+        kind: ServiceBinding
+        metadata:
+            name: $scenario_id
+        spec:
+            service:
+                apiVersion: stable.example.com/v1
+                kind: ProvisionedBackend
+                name: $scenario_id
+            workload:
+                apiVersion: apps/v1
+                kind: Deployment
+                name: $scenario_id
         """
     Then Service Binding becomes ready
     And Content of file "/bindings/external/$scenario_id/username" in workload pod is

--- a/features/bindAppToProvisionedService.feature
+++ b/features/bindAppToProvisionedService.feature
@@ -2,60 +2,184 @@ Feature: Bind workload to provisioned service
 
   As a user I would like to bind my applications to provisioned services, as defined by the binding spec
 
-  Scenario: SPEC Bind workload to provisioned service
+  Background:
     Given Namespace [TEST_NAMESPACE] is used
-    And The Secret is present
-            """
-            apiVersion: v1
-            kind: Secret
-            metadata:
-                name: $scenario_id
-            stringData:
-                username: foo
-                password: bar
-                type: db
-            """
     And CRD "provisioned_backend" is available
-    And The Custom Resource is present
-            """
-            apiVersion: stable.example.com/v1
-            kind: ProvisionedBackend
-            metadata:
-                name: $scenario_id
-            spec:
-                foo: bar
-            status:
-                binding:
-                    name: $scenario_id
-            """
+    And The Secret is present
+        """
+        apiVersion: v1
+        kind: Secret
+        metadata:
+            name: provisioned-secret
+        stringData:
+            username: foo
+            password: bar
+            type: db
+        """
+
+  Scenario: Bind workload to provisioned service
+    Given The Custom Resource is present
+        """
+        apiVersion: stable.example.com/v1
+        kind: ProvisionedBackend
+        metadata:
+            name: $scenario_id
+        spec:
+            foo: bar
+        status:
+            binding:
+                name: provisioned-secret
+        """
     And Generic test application is running
     When Service Binding is applied
-          """
-          apiVersion: servicebinding.io/v1alpha3
-          kind: ServiceBinding
-          metadata:
-              name: $scenario_id
-          spec:
-              service:
+        """
+        apiVersion: servicebinding.io/v1beta1
+        kind: ServiceBinding
+        metadata:
+            name: $scenario_id
+        spec:
+            service:
                 apiVersion: stable.example.com/v1
                 kind: ProvisionedBackend
                 name: $scenario_id
-              workload:
-                name: $scenario_id
+            workload:
                 apiVersion: apps/v1
                 kind: Deployment
-          """
+                name: $scenario_id
+        """
     Then Service Binding becomes ready
-    And jq ".status.binding.name" of Service Binding should be changed to "$scenario_id"
+    And jq ".status.binding.name" of Service Binding should be changed to "provisioned-secret"
     And Content of file "/bindings/$scenario_id/username" in workload pod is
-            """
-            foo
-            """
+        """
+        foo
+        """
     And Content of file "/bindings/$scenario_id/password" in workload pod is
-            """
-            bar
-            """
+        """
+        bar
+        """
     And Content of file "/bindings/$scenario_id/type" in workload pod is
-            """
-            db
-            """
+        """
+        db
+        """
+
+  Scenario: Fall back to default if SERVICE_BINDING_ROOT is not set
+    Given The Custom Resource is present
+        """
+        apiVersion: stable.example.com/v1
+        kind: ProvisionedBackend
+        metadata:
+            name: $scenario_id
+        spec:
+            foo: bar
+        status:
+            binding:
+                name: provisioned-secret
+        """
+    And Generic test application is running
+    When Service Binding is applied
+        """
+        apiVersion: servicebinding.io/v1beta1
+        kind: ServiceBinding
+        metadata:
+          name: $scenario_id
+        spec:
+            service:
+                apiVersion: stable.example.com/v1
+                kind: ProvisionedBackend
+                name: $scenario_id
+            workload:
+                apiVersion: apps/v1
+                kind: Deployment
+                name: $scenario_id
+        """
+    Then Service Binding becomes ready
+    And The service binding root is valid
+
+  Scenario: Override type in provisioned service with values from ServiceBinding
+    Given The Custom Resource is present
+        """
+        apiVersion: stable.example.com/v1
+        kind: ProvisionedBackend
+        metadata:
+            name: $scenario_id
+        spec:
+            foo: bar
+        status:
+            binding:
+                name: provisioned-secret
+        """
+    And Generic test application is running
+    When Service Binding is applied
+        """
+        apiVersion: servicebinding.io/v1beta1
+        kind: ServiceBinding
+        metadata:
+          name: $scenario_id
+        spec:
+          service:
+            apiVersion: stable.example.com/v1
+            kind: ProvisionedBackend
+            name: $scenario_id
+          type: baz
+          workload:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: $scenario_id
+        """
+    Then Service Binding becomes ready
+    And Content of file "/bindings/$scenario_id/username" in workload pod is
+        """
+        foo
+        """
+    And Content of file "/bindings/$scenario_id/password" in workload pod is
+        """
+        bar
+        """
+    And Content of file "/bindings/$scenario_id/type" in workload pod is
+        """
+        baz
+        """
+
+  Scenario: Override provider in provisioned service with values from ServiceBinding
+    Given The Custom Resource is present
+        """
+        apiVersion: stable.example.com/v1
+        kind: ProvisionedBackend
+        metadata:
+            name: $scenario_id
+        spec:
+            foo: bar
+        status:
+            binding:
+                name: provisioned-secret
+        """
+    And Generic test application is running with binding root as "/bindings/external"
+    When Service Binding is applied
+        """
+        apiVersion: servicebinding.io/v1beta1
+        kind: ServiceBinding
+        metadata:
+            name: $scenario_id
+        spec:
+            service:
+              apiVersion: stable.example.com/v1
+              kind: ProvisionedBackend
+              name: $scenario_id
+            workload:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: $scenario_id
+        """
+    Then Service Binding becomes ready
+    And Content of file "/bindings/external/$scenario_id/username" in workload pod is
+        """
+        foo
+        """
+    And Content of file "/bindings/external/$scenario_id/password" in workload pod is
+        """
+        bar
+        """
+    And Content of file "/bindings/external/$scenario_id/type" in workload pod is
+        """
+        db
+        """

--- a/features/environment.py
+++ b/features/environment.py
@@ -26,7 +26,7 @@ def before_all(_context):
     assert code == 0, "CRD servicebindings.servicebinding.io not available"
 
     output, code = cmd.run("jq '.spec.versions[] | select(.served == true) | .name'", stdin=service_binding_crd)
-    assert code == 0 and "v1alpha3" in output, "CRD servicebindings.servicebinding.io/v1alpha3 not served"
+    assert code == 0 and "v1beta1" in output, "CRD servicebindings.servicebinding.io/v1beta1 must be served"
 
 
 def before_scenario(_context, _scenario):

--- a/features/steps/cluster.py
+++ b/features/steps/cluster.py
@@ -192,7 +192,7 @@ spec:
         cmd = f"{ctx.cli} create deployment {name} -n {namespace} --image={image_name}"
         if bindingRoot:
             yaml = self.deployment_template.format(name=name, image_name=image_name, namespace=namespace, bindingRoot=bindingRoot)
-            self.apply(self, yaml, namespace=namespace)
+            self.apply(yaml, namespace=namespace)
         else:
             (output, exit_code) = self.cmd.run(cmd)
             assert exit_code == 0, f"Non-zero exit code ({exit_code}) returned when attempting to create a new app using following command line {cmd}\n: {output}"

--- a/features/steps/generic_testapp.py
+++ b/features/steps/generic_testapp.py
@@ -64,3 +64,9 @@ def check_binding_root(context, name="SERVICE_BINDING_ROOT"):
     # for now, assert a non-zero-length string
     found = polling2.poll(lambda: context.application.get_env_var_value(name), step=5, timeout=400)
     assert len(found) != 0, f'Env var "{name}" should be set'
+
+@then(u'The projected binding "{binding_name}" has "{key}" set to')
+def step_impl(context, binding_name, key):
+    binding_root = polling2.poll(lambda: context.application.get_env_var_value("SERVICE_BINDING_ROOT"), step=5, timeout=400)
+    binding_path = binding_root + '/' + substitute_scenario_id(context, binding_name) + '/' + key
+    check_file_value(context, binding_path)

--- a/features/steps/generic_testapp.py
+++ b/features/steps/generic_testapp.py
@@ -11,7 +11,7 @@ class GenericTestApp(App):
 
     deployment_name_pattern = "{name}"
 
-    def __init__(self, name, namespace, app_image="ghcr.io/servicebindings/generic-test-app"):
+    def __init__(self, name, namespace, app_image="ghcr.io/servicebindings/generic-test-app:main"):
         App.__init__(self, name, namespace, app_image, "8080")
 
     def get_env_var_value(self, name):

--- a/features/steps/generic_testapp.py
+++ b/features/steps/generic_testapp.py
@@ -11,8 +11,17 @@ class GenericTestApp(App):
 
     deployment_name_pattern = "{name}"
 
-    def __init__(self, name, namespace, app_image="ghcr.io/servicebinding/generic-test-app"):
+    def __init__(self, name, namespace, app_image="ghcr.io/servicebindings/generic-test-app"):
         App.__init__(self, name, namespace, app_image, "8080")
+
+    def get_env_var_value(self, name):
+        resp = polling2.poll(lambda: requests.get(url=f"http://{self.route_url}/env/{name}"),
+                             check_success=lambda r: r.status_code in [200, 404], step=5, timeout=400, ignore_exceptions=(requests.exceptions.ConnectionError,))
+        print(f'env endpoint response: {resp.text} code: {resp.status_code}')
+        if resp.status_code == 200:
+            return json.loads(resp.text)
+        else:
+            return None
 
     def format_pattern(self, pattern):
         return pattern.format(name=self.name)
@@ -28,12 +37,13 @@ class GenericTestApp(App):
 
 
 @step(u'Generic test application is running')
-def is_running(context):
+@step(u'Generic test application is running with binding root as "{bindingRoot}"')
+def is_running(context, bindingRoot=None):
     application_name = substitute_scenario_id(context)
     application = GenericTestApp(application_name, context.namespace.name)
     if not application.is_running():
         print("application is not running, trying to import it")
-        application.install()
+        application.install(bindingRoot=bindingRoot)
     context.application = application
 
 @step(u'Content of file "{file_path}" in workload pod is')
@@ -41,3 +51,16 @@ def check_file_value(context, file_path):
     value = Template(context.text.strip()).substitute(NAMESPACE=context.namespace.name)
     resource = substitute_scenario_id(context, file_path)
     polling2.poll(lambda: context.application.get_file_value(resource) == value, step=5, timeout=400)
+
+@step(u'The application env var "{name}" has value "{value}"')
+def check_env_var_value(context, name, value=None):
+    value = substitute_scenario_id(context, value)
+    found = polling2.poll(lambda: context.application.get_env_var_value(name) == value, step=5, timeout=400)
+    assert found, f'Env var "{name}" should contain value "{value}"'
+
+@step(u'The service binding root is valid')
+def check_binding_root(context, name="SERVICE_BINDING_ROOT"):
+    # TODO: check that this is a valid path within the container
+    # for now, assert a non-zero-length string
+    found = polling2.poll(lambda: context.application.get_env_var_value(name), step=5, timeout=400)
+    assert len(found) != 0, f'Env var "{name}" should be set'

--- a/features/steps/service_binding.py
+++ b/features/steps/service_binding.py
@@ -62,8 +62,6 @@ def operator_is_ready(context, sbr_name=None):
         sbr_name = list(context.bindings.values())[0].name
     else:
         sbr_name = substitute_scenario_id(context, sbr_name)
-    jq_is(context, '.status.conditions[] | select(.type=="CollectionReady").status', sbr_name, 'True')
-    jq_is(context, '.status.conditions[] | select(.type=="InjectionReady").status', sbr_name, 'True')
     jq_is(context, '.status.conditions[] | select(.type=="Ready").status', sbr_name, 'True')
     sb = context.bindings[sbr_name]
     generation = sb.get_info_by_jsonpath("{.metadata.generation}")

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -30,7 +30,7 @@ def operator_manifest_installed(context, backend_service=None):
 
 # STEP
 @given(u'The Custom Resource is present')
-@given(u'The Secret is present')
+@step(u'The Secret is present')
 def apply_yaml(context, user=None):
     cluster = Cluster()
     resource = substitute_scenario_id(context, context.text)


### PR DESCRIPTION
Implement more tests surrounding the provisioned service specification.  This should implement coverage for a few scenarios:

- [x] Binding a workload with a provisioned service
- [x] Overriding `type` in the `ServiceBinding`
- [x] Overriding `provider` in the `ServiceBinding`
- [x] Overriding `$SERVICE_BINDING_ROOT` in the workload
- [x] Have `$SERVICE_BINDING_ROOT` fall back to a default when not specified