### PR TITLE
Direct secret projection

### DIFF
--- a/features/directSecretReference.feature
+++ b/features/directSecretReference.feature
@@ -1,0 +1,116 @@
+Feature: Direct Secret Reference
+
+    As a user, I would like to inject into my app values from a secret referred
+    to by the service binding
+
+    Background:
+        Given Namespace [TEST_NAMESPACE] is used
+
+    Scenario: Inject binding to a workload from a Secret resource referred as service
+        Given The Secret is present
+            """
+            apiVersion: v1
+            kind: Secret
+            metadata:
+                name: $scenario_id
+            stringData:
+                username: foo
+                password: bar
+                type: db
+            """
+        And Generic test application is running
+        When Service Binding is applied
+            """
+            apiVersion: servicebinding.io/v1beta1
+            kind: ServiceBinding
+            metadata:
+                name: $scenario_id-binding
+            spec:
+                service:
+                    apiVersion: v1
+                    kind: Secret
+                    name: $scenario_id
+                workload:
+                    name: $scenario_id
+                    apiVersion: apps/v1
+                    kind: Deployment
+            """
+        Then Service Binding becomes ready
+        And Content of file "/bindings/$scenario_id-binding/username" in workload pod is
+            """
+            foo
+            """
+        And Content of file "/bindings/$scenario_id-binding/password" in workload pod is
+            """
+            bar
+            """
+        And Content of file "/bindings/$scenario_id-binding/type" in workload pod is
+            """
+            db
+            """
+
+    Scenario: Altering a secret after using it in a binding should reflect new values
+        Given The Secret is present
+            """
+            apiVersion: v1
+            kind: Secret
+            metadata:
+                name: $scenario_id
+            stringData:
+                username: foo
+                password: bar
+                type: db
+            """
+        And Generic test application is running
+        And Service Binding is applied
+            """
+            apiVersion: servicebinding.io/v1beta1
+            kind: ServiceBinding
+            metadata:
+                name: $scenario_id-binding
+            spec:
+                service:
+                    apiVersion: v1
+                    kind: Secret
+                    name: $scenario_id
+                workload:
+                    name: $scenario_id
+                    apiVersion: apps/v1
+                    kind: Deployment
+            """
+        And Service Binding becomes ready
+        And Content of file "/bindings/$scenario_id-binding/username" in workload pod is
+            """
+            foo
+            """
+        And Content of file "/bindings/$scenario_id-binding/password" in workload pod is
+            """
+            bar
+            """
+        And Content of file "/bindings/$scenario_id-binding/type" in workload pod is
+            """
+            db
+            """
+        When The Secret is present
+            """
+            apiVersion: v1
+            kind: Secret
+            metadata:
+                name: $scenario_id
+            stringData:
+                username: spam
+                password: eggs
+                type: ham
+            """
+        Then Content of file "/bindings/$scenario_id-binding/username" in workload pod is
+            """
+            spam
+            """
+        And Content of file "/bindings/$scenario_id-binding/password" in workload pod is
+            """
+            eggs
+            """
+        And Content of file "/bindings/$scenario_id-binding/type" in workload pod is
+            """
+            ham
+            """

--- a/features/steps/service_binding.py
+++ b/features/steps/service_binding.py
@@ -56,6 +56,7 @@ def sbr_is_applied(context, user=None):
     context.bindings[binding.name] = binding
     context.sb_secret = ""
 
+
 @step(u'Service Binding becomes ready')
 def operator_is_ready(context, sbr_name=None):
     if sbr_name is None:

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -7,10 +7,8 @@ import re
 import yaml
 import json
 
-from behave import given
-from namespace import Namespace
+from behave import given, step
 from cluster import Cluster
-from app import App
 from util import substitute_scenario_id
 
 
@@ -31,7 +29,7 @@ def operator_manifest_installed(context, backend_service=None):
 # STEP
 @given(u'The Custom Resource is present')
 @step(u'The Secret is present')
-def apply_yaml(context, user=None):
+def apply_yaml(context):
     cluster = Cluster()
     resource = substitute_scenario_id(context, context.text)
     metadata = yaml.full_load(resource)["metadata"]
@@ -43,8 +41,7 @@ def apply_yaml(context, user=None):
             ns = context.namespace.name
         else:
             ns = None
-    output = cluster.apply(resource, ns, user)
+    output = cluster.apply(resource, ns)
     result = re.search(rf'.*{metadata_name}.*(created|unchanged|configured)', output)
     assert result is not None, f"Unable to apply YAML for CR '{metadata_name}': {output}"
     return metadata
-


### PR DESCRIPTION
Implements tests for direct secret projection.  Implemented scenarios:
 - Inject binding to a workload from a Secret resource referred as service
 - Bind a workload before the secret is created
 - Fail to bind if the secret does not exist
 - Altering a secret after using it in a binding should reflect new values

Note: The reference implementation fails the third test.  I believe this test is what the spec requires, but would like a second pair of eyes specifically on that test.

Depends on #5.