### PR TITLE
Move generic-test-app image under conformance repo

### DIFF
--- a/.github/workflows/merge-to-main.yaml
+++ b/.github/workflows/merge-to-main.yaml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/generic-test-app
+  IMAGE_NAME: ${{ github.repository }}/generic-test-app
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Push dependencies
       run: |
         eval $(minikube docker-env)
-        docker build -t ghcr.io/servicebindings/generic-test-app:main resources/apps/generic-test-app
+        docker build -t ghcr.io/${{ github.repository }}/generic-test-app:main resources/apps/generic-test-app
 
         # TODO: actually have an operator here
         kubectl apply -f .github/resources/servicebinding_crds.yaml

--- a/features/steps/generic_testapp.py
+++ b/features/steps/generic_testapp.py
@@ -11,7 +11,7 @@ class GenericTestApp(App):
 
     deployment_name_pattern = "{name}"
 
-    def __init__(self, name, namespace, app_image="ghcr.io/servicebindings/generic-test-app:main"):
+    def __init__(self, name, namespace, app_image="ghcr.io/servicebindings/conformance/generic-test-app:main"):
         App.__init__(self, name, namespace, app_image, "8080")
 
     def get_env_var_value(self, name):


### PR DESCRIPTION
This should make it public by default, allowing more flexible use of it in testing scenarios.

Signed-off-by: Andy Sadler <ansadler@redhat.com>