### PR TITLE
Rename CI job

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   it_runs:
-    name: Run tests against an empty cluster
+    name: Run tests against reference implementation
     runs-on: ubuntu-20.04
     steps:
     - name: Set up Python


### PR DESCRIPTION
We changed the CI job in #12 to run tests against the reference implementation.  We should reflect this in our job title.

Signed-off-by: Andy Sadler <ansadler@redhat.com>