### PR TITLE
tests: label selectors in service bindings

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -29,5 +29,6 @@ def before_all(_context):
 
 def before_scenario(_context, _scenario):
     _context.bindings = dict()
+    _context.workloads = dict()
     output, code = cmd.run(f'{ctx.cli} get ns default -o jsonpath="{{.metadata.name}}"')
     assert code == 0, f"Checking connection to OS cluster by getting the 'default' project failed: {output}"

--- a/features/labelSelectors.feature
+++ b/features/labelSelectors.feature
@@ -1,0 +1,218 @@
+Feature: Bind workloads matching a label selector to a service
+
+    As a user, I want to bind workloads that match a particular label selector
+
+    Background:
+        Given Namespace [TEST_NAMESPACE] is used
+        And The Secret is present
+            """
+            apiVersion: v1
+            kind: Secret
+            metadata:
+                name: $scenario_id
+            stringData:
+                username: foo
+                password: bar
+                type: baz
+            """
+
+    Scenario: Bind a workload matching a label selector to a service
+        Given Generic test application is running with binding root as "/bindings" and labeled as "app-custom=$scenario_id"
+        When Service Binding is applied
+            """
+            apiVersion: servicebinding.io/v1beta1
+            kind: ServiceBinding
+            metadata:
+                name: $scenario_id
+            spec:
+                service:
+                    apiVersion: v1
+                    kind: Secret
+                    name: $scenario_id
+                workload:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    selector:
+                        matchLabels:
+                            app-custom: $scenario_id
+            """
+        Then Service Binding becomes ready
+        And Content of file "/bindings/$scenario_id/username" in workload pod is
+            """
+            foo
+            """
+        And Content of file "/bindings/$scenario_id/password" in workload pod is
+            """
+            bar
+            """
+        And Content of file "/bindings/$scenario_id/type" in workload pod is
+            """
+            baz
+            """
+
+    Scenario: Bind two workloads to a single service
+        Given Generic test application "$scenario_id-1" is running with binding root as "/bindings" and labeled as "app-custom=$scenario_id"
+        Given Generic test application "$scenario_id-2" is running with binding root as "/bindings" and labeled as "app-custom=$scenario_id"
+        When Service Binding is applied
+            """
+            apiVersion: servicebinding.io/v1beta1
+            kind: ServiceBinding
+            metadata:
+                name: $scenario_id
+            spec:
+                service:
+                    apiVersion: v1
+                    kind: Secret
+                    name: $scenario_id
+                workload:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    selector:
+                        matchLabels:
+                            app-custom: $scenario_id
+            """
+        Then Service Binding becomes ready
+        And Content of file "/bindings/$scenario_id/username" in workload pod "$scenario_id-1" is
+            """
+            foo
+            """
+        And Content of file "/bindings/$scenario_id/password" in workload pod "$scenario_id-1" is
+            """
+            bar
+            """
+        And Content of file "/bindings/$scenario_id/type" in workload pod "$scenario_id-1" is
+            """
+            baz
+            """
+        And Content of file "/bindings/$scenario_id/username" in workload pod "$scenario_id-2" is
+            """
+            foo
+            """
+        And Content of file "/bindings/$scenario_id/password" in workload pod "$scenario_id-2" is
+            """
+            bar
+            """
+        And Content of file "/bindings/$scenario_id/type" in workload pod "$scenario_id-2" is
+            """
+            baz
+            """
+
+    Scenario: Bind a labeled workload submitted after the service binding
+        Given Service Binding is applied
+            """
+            apiVersion: servicebinding.io/v1beta1
+            kind: ServiceBinding
+            metadata:
+                name: $scenario_id
+            spec:
+                service:
+                    apiVersion: v1
+                    kind: Secret
+                    name: $scenario_id
+                workload:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    selector:
+                        matchLabels:
+                            app-custom: $scenario_id
+            """
+        When Generic test application is running with binding root as "/bindings" and labeled as "app-custom=$scenario_id"
+        Then Service Binding becomes ready
+        And Content of file "/bindings/$scenario_id/username" in workload pod is
+            """
+            foo
+            """
+        And Content of file "/bindings/$scenario_id/password" in workload pod is
+            """
+            bar
+            """
+        And Content of file "/bindings/$scenario_id/type" in workload pod is
+            """
+            baz
+            """
+
+    Scenario: Bind labeled workloads with a already successful service binding
+        Given Generic test application "$scenario_id-1" is running with binding root as "/bindings" and labeled as "app-custom=$scenario_id"
+        And Service Binding is applied
+            """
+            apiVersion: servicebinding.io/v1beta1
+            kind: ServiceBinding
+            metadata:
+                name: $scenario_id
+            spec:
+                service:
+                    apiVersion: v1
+                    kind: Secret
+                    name: $scenario_id
+                workload:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    selector:
+                        matchLabels:
+                            app-custom: $scenario_id
+            """
+        And Service Binding becomes ready
+        When Generic test application "$scenario_id-2" is running with binding root as "/bindings" and labeled as "app-custom=$scenario_id"
+        Then Service Binding becomes ready
+        And Content of file "/bindings/$scenario_id/username" in workload pod "$scenario_id-1" is
+            """
+            foo
+            """
+        And Content of file "/bindings/$scenario_id/password" in workload pod "$scenario_id-1" is
+            """
+            bar
+            """
+        And Content of file "/bindings/$scenario_id/type" in workload pod "$scenario_id-1" is
+            """
+            baz
+            """
+        And Content of file "/bindings/$scenario_id/username" in workload pod "$scenario_id-2" is
+            """
+            foo
+            """
+        And Content of file "/bindings/$scenario_id/password" in workload pod "$scenario_id-2" is
+            """
+            bar
+            """
+        And Content of file "/bindings/$scenario_id/type" in workload pod "$scenario_id-2" is
+            """
+            baz
+            """
+
+    Scenario: Changing a workload's label unbinds the service
+        Given Generic test application is running with binding root as "/bindings" and labeled as "app-custom=$scenario_id-1"
+        And Service Binding is applied
+            """
+            apiVersion: servicebinding.io/v1beta1
+            kind: ServiceBinding
+            metadata:
+                name: $scenario_id
+            spec:
+                service:
+                    apiVersion: v1
+                    kind: Secret
+                    name: $scenario_id
+                workload:
+                    apiVersion: apps/v1
+                    kind: Deployment
+                    selector:
+                        matchLabels:
+                            app-custom: $scenario_id-1
+            """
+        And Service Binding becomes ready
+        And Content of file "/bindings/$scenario_id/username" in workload pod is
+            """
+            foo
+            """
+        And Content of file "/bindings/$scenario_id/password" in workload pod is
+            """
+            bar
+            """
+        And Content of file "/bindings/$scenario_id/type" in workload pod is
+            """
+            baz
+            """
+        When Generic test application is running with binding root as "/bindings" and labeled as "app-custom=$scenario_id-2"
+        Then File "/bindings/$scenario_id/username" is unavailable in workload pod
+        And  File "/bindings/$scenario_id/password" is unavailable in workload pod
+        And  File "/bindings/$scenario_id/type" is unavailable in workload pod

--- a/features/steps/cluster.py
+++ b/features/steps/cluster.py
@@ -193,10 +193,11 @@ spec:
             for obj in parsed['spec']['template']['spec']['containers']:
                 obj['env'] = [{'name': 'SERVICE_BINDING_ROOT', 'value': bindingRoot}]
             formatted = yaml.dump(parsed)
+        print(f'applying deployment: {formatted}')
         self.apply(formatted, namespace=namespace)
 
     def set_label(self, name, label, namespace):
-        cmd = f"{ctx.cli} label deployments {name} '{label}' -n {namespace}"
+        cmd = f"{ctx.cli} label deployments {name} '{label}' -n {namespace} --overwrite"
         (output, exit_code) = self.cmd.run(cmd)
         assert exit_code == 0, f"Non-zero exit code ({exit_code}) returned when attempting set label: {cmd}\n: {output}"
 

--- a/features/steps/generic_testapp.py
+++ b/features/steps/generic_testapp.py
@@ -24,6 +24,11 @@ class GenericTestApp(App):
         else:
             return None
 
+    def assert_file_not_exist(self, file_path):
+        polling2.poll(lambda: requests.get(url=f"http://{self.route_url}{file_path}"),
+                      check_success=lambda r: r.status_code == 404, step=5, timeout=400,
+                      ignore_exceptions=(requests.exceptions.ConnectionError,))
+
     def format_pattern(self, pattern):
         return pattern.format(name=self.name)
 
@@ -40,26 +45,50 @@ class GenericTestApp(App):
 
 @step(u'Generic test application is running')
 @step(u'Generic test application is running with binding root as "{bindingRoot}"')
-def is_running(context, bindingRoot=None):
-    application_name = substitute_scenario_id(context)
+@step(u'Generic test application is running with binding root as "{bindingRoot}" and labeled as "{label}"')
+@step(u'Generic test application "{name}" is running with binding root as "{bindingRoot}" and labeled as "{label}"')
+def is_running(context, name=None, bindingRoot=None, label=None):
+    if name is None:
+        application_name = substitute_scenario_id(context)
+    else:
+        application_name = substitute_scenario_id(context, name)
     application = GenericTestApp(application_name, context.namespace.name)
+    print(f'application name: {application_name}')
+    print(f'{application.name}')
     if not application.is_running():
         print("application is not running, trying to import it")
         application.install(bindingRoot=bindingRoot)
-    context.application = application
+    if label is not None:
+        label = substitute_scenario_id(context, label)
+        application.set_label(label)
+    context.workload = application
+    context.workloads[application_name] = application
 
 
 @step(u'Content of file "{file_path}" in workload pod is')
-def check_file_value(context, file_path):
+@step(u'Content of file "{file_path}" in workload pod "{name}" is')
+def check_file_value(context, file_path, name=None):
+    print(f'known workloads: {context.workloads}')
+    workload = context.workload
+    if name is not None:
+        name = substitute_scenario_id(context, name)
+        print(f'using workload "{name}"')
+        workload = context.workloads[name]
     value = Template(context.text.strip()).substitute(NAMESPACE=context.namespace.name)
     resource = substitute_scenario_id(context, file_path)
-    polling2.poll(lambda: context.application.get_file_value(resource) == value, step=5, timeout=400)
+    polling2.poll(lambda: workload.get_file_value(resource) == value, step=5, timeout=400)
+
+
+@step(u'File "{file_path}" is unavailable in workload pod')
+def check_file_unavailable(context, file_path):
+    file_path = substitute_scenario_id(context, file_path)
+    context.workload.assert_file_not_exist(file_path)
 
 
 @step(u'The application env var "{name}" has value "{value}"')
 def check_env_var_value(context, name, value=None):
     value = substitute_scenario_id(context, value)
-    found = polling2.poll(lambda: context.application.get_env_var_value(name) == value, step=5, timeout=400)
+    found = polling2.poll(lambda: context.workload.get_env_var_value(name) == value, step=5, timeout=400)
     assert found, f'Env var "{name}" should contain value "{value}"'
 
 
@@ -67,13 +96,13 @@ def check_env_var_value(context, name, value=None):
 def check_binding_root(context, name="SERVICE_BINDING_ROOT"):
     # TODO: check that this is a valid path within the container
     # for now, assert a non-zero-length string
-    found = polling2.poll(lambda: context.application.get_env_var_value(name), step=5, timeout=400)
+    found = polling2.poll(lambda: context.workload.get_env_var_value(name), step=5, timeout=400)
     assert len(found) != 0, f'Env var "{name}" should be set'
 
 
 @then(u'The projected binding "{binding_name}" has "{key}" set to')
 def check_binding_value(context, binding_name, key):
-    binding_root = polling2.poll(lambda: context.application.get_env_var_value("SERVICE_BINDING_ROOT"),
+    binding_root = polling2.poll(lambda: context.workload.get_env_var_value("SERVICE_BINDING_ROOT"),
                                  step=5, timeout=400)
     binding_path = binding_root + '/' + substitute_scenario_id(context, binding_name) + '/' + key
     check_file_value(context, binding_path)


### PR DESCRIPTION
Adds 7 tests:

- Bind an workload matching a label selector to a service
- Bind two workloads to a single service
- Bind a labeled workload submitted after the service binding
- Bind labeled workloads with a already successful service binding
- Changing a workload's label unbinds the service
- A workload should not be bound if it doesn't match the label in the service binding
- Only bind workloads with the correct label

Signed-off-by: Andy Sadler <ansadler@redhat.com>