### PR TITLE
Implement linting checks

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -37,3 +37,17 @@ jobs:
         kapp deploy -y -a servicebinding-runtime -f https://github.com/servicebinding/runtime/releases/download/v0.1.1/servicebinding-runtime-v0.1.1.yaml
     - name: Conformance tests
       run: .github/resources/run_ci.sh
+  
+  linting:
+    name: Lint checks
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+        architecture: "x64"
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run linting checks
+      run: hack/lint-python-code.sh

--- a/features/environment.py
+++ b/features/environment.py
@@ -15,8 +15,6 @@ before_all(context), after_all(context)
 from steps.command import Command
 from steps.environment import ctx
 
-import os
-
 cmd = Command()
 
 

--- a/features/steps/app.py
+++ b/features/steps/app.py
@@ -1,10 +1,7 @@
 from cluster import Cluster
 from command import Command
 from environment import ctx
-from behave import step
-from util import substitute_scenario_id
 import polling2
-import json
 
 
 class App(object):
@@ -27,7 +24,8 @@ class App(object):
 
     def is_running(self, wait=False):
         output, exit_code = self.cmd.run(
-            f"{ctx.cli} wait --for=condition=Available=True {self.resource}/{self.name} -n {self.namespace} --timeout={300 if wait else 0}s")
+            f"{ctx.cli} wait --for=condition=Available=True {self.resource}/{self.name} -n \
+                    {self.namespace} --timeout={300 if wait else 0}s")
         running = exit_code == 0
         if running:
             self.route_url = polling2.poll(lambda: self.base_url(),
@@ -44,5 +42,7 @@ class App(object):
 
     def get_generation(self):
         deployment_name = self.cluster.get_deployment_name_in_namespace(
-                            self.format_pattern(self.deployment_name_pattern), self.namespace, resource=self.resource)
-        return int(self.cluster.get_resource_info_by_jsonpath(self.resource, deployment_name, self.namespace, "{.metadata.generation}"))
+            self.format_pattern(self.deployment_name_pattern), self.namespace, resource=self.resource)
+        result = self.cluster.get_resource_info_by_jsonpath(self.resource, deployment_name,
+                                                            self.namespace, "{.metadata.generation}")
+        return int(result)

--- a/features/steps/command.py
+++ b/features/steps/command.py
@@ -1,5 +1,4 @@
 import subprocess
-import time
 import os
 
 
@@ -14,10 +13,10 @@ class Command(object):
             self.path = path
 
         kubeconfig = os.getenv("KUBECONFIG")
-        if kubeconfig == None:
+        if kubeconfig is None:
             kubeconfig = f"{os.path.expanduser('~')}/.kube/config"
         available = os.path.isfile(kubeconfig)
-        assert available == True, "Unable to find current kubernetes context!"
+        assert available, "Unable to find current kubernetes context!"
         self.setenv("KUBECONFIG", kubeconfig)
 
         path = os.getenv("PATH")
@@ -25,7 +24,8 @@ class Command(object):
         self.setenv("PATH", path)
 
     def setenv(self, key, value):
-        assert key is not None and value is not None, f"Name or value of the environment variable cannot be None: [{key} = {value}]"
+        assert key is not None and value is not None, \
+            f"Name or value of the environment variable cannot be None: [{key} = {value}]"
         self.env[key] = value
 
     def run(self, cmd, stdin=None):
@@ -36,7 +36,8 @@ class Command(object):
             if stdin is None:
                 output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, cwd=self.path, env=self.env)
             else:
-                output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, cwd=self.path, env=self.env, input=stdin.encode("utf-8"))
+                output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, cwd=self.path,
+                                                 env=self.env, input=stdin.encode("utf-8"))
         except subprocess.CalledProcessError as err:
             output = err.output
             exit_code = err.returncode

--- a/features/steps/service_binding.py
+++ b/features/steps/service_binding.py
@@ -1,7 +1,7 @@
 import yaml
 import polling2
 import json
-from behave import step, when, then
+from behave import step
 from cluster import Cluster
 from util import substitute_scenario_id
 
@@ -84,4 +84,4 @@ def jq_is(context, jq_expression, sbr_name=None, json_value=""):
     json_value = substitute_scenario_id(context, json_value)
     polling2.poll(lambda: json.loads(
         context.bindings[sbr_name].get_info_by_jsonpath(jq_expression)) == json_value,
-                  step=5, timeout=800, ignore_exceptions=(json.JSONDecodeError,))
+        step=5, timeout=800, ignore_exceptions=(json.JSONDecodeError,))

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -5,7 +5,6 @@
 import os
 import re
 import yaml
-import json
 
 from behave import given, step
 from cluster import Cluster
@@ -21,9 +20,10 @@ def operator_manifest_installed(context, backend_service=None):
         ns = None
 
     if backend_service is None:
-        _ = cluster.apply_yaml_file(os.path.join(os.getcwd(), "resources/backend_crd.yaml"), namespace=ns)
+        cluster.apply_yaml_file(os.path.join(os.getcwd(), "resources/backend_crd.yaml"), namespace=ns)
     else:
-        _ = cluster.apply_yaml_file(os.path.join(os.getcwd(), "resources/", backend_service + ".operator.manifest.yaml"), namespace=ns)
+        cluster.apply_yaml_file(os.path.join(os.getcwd(), "resources/", backend_service + ".operator.manifest.yaml"),
+                                namespace=ns)
 
 
 # STEP

--- a/hack/check-PEP8-style.sh
+++ b/hack/check-PEP8-style.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+. ./hack/prepare-env.sh
+
+echo "----------------------------------------------------"
+echo "Running Python linter against following directories:"
+echo "$directories"
+echo "----------------------------------------------------"
+echo
+
+[ "$NOVENV" == "1" ] || prepare_venv || exit 1
+
+# checks for the whole directories
+for directory in $directories
+do
+    files=$(find "$directory" -path "$PYTHON_VENV_DIR" -prune -o -name '*.py' -print)
+
+    for source in $files
+    do
+        echo "$source"
+        $PYTHON_VENV_DIR/bin/pycodestyle "$source"
+        if [ $? -eq 0 ]
+        then
+            echo "    Pass"
+            let "pass++"
+        else
+            echo "    Fail"
+            let "fail++"
+        fi
+    done
+done
+
+
+if [ $fail -eq 0 ]
+then
+    echo "All checks passed for $pass source files"
+else
+    let total=$pass+$fail
+    echo "Linter fail, $fail source files out of $total source files need to be fixed"
+    exit 1
+fi

--- a/hack/detect-common-errors.sh
+++ b/hack/detect-common-errors.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+. ./hack/prepare-env.sh
+
+# run the pyflakes for all files that are provided in $1
+function check_files() {
+    for source in $1
+    do
+        echo "$source"
+        $PYTHON_VENV_DIR/bin/pyflakes "$source"
+        if [ $? -eq 0 ]
+        then
+            echo "    Pass"
+            let "pass++"
+        elif [ $? -eq 2 ]
+        then
+            echo "    Illegal usage (should not happen)"
+            exit 2
+        else
+            echo "    Fail"
+            let "fail++"
+        fi
+    done
+}
+
+
+echo "----------------------------------------------------"
+echo "Checking source files for common errors in following"
+echo "directories:"
+echo "$directories"
+echo "----------------------------------------------------"
+echo
+
+[ "$NOVENV" == "1" ] || prepare_venv || exit 1
+
+# checks for the whole directories
+for directory in $directories
+do
+    pwd
+    files=$(find "$directory" -path "$PYTHON_VENV_DIR" -prune -o -name '*.py' -print)
+
+    check_files "$files"
+done
+
+
+if [ $fail -eq 0 ]
+then
+    echo "All checks passed for $pass source files"
+else
+    let total=$pass+$fail
+    echo "$fail source files out of $total files needs to be checked and fixed"
+    exit 1
+fi

--- a/hack/detect-dead-code.sh
+++ b/hack/detect-dead-code.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+. ./hack/prepare-env.sh
+
+# run the vulture for all files that are provided in $1
+function check_files() {
+    for source in $1
+    do
+        echo "$source"
+        $PYTHON_VENV_DIR/bin/vulture --min-confidence 90 "$source"
+        if [ $? -eq 0 ]
+        then
+            echo "    Pass"
+            let "pass++"
+        elif [ $? -eq 2 ]
+        then
+            echo "    Illegal usage (should not happen)"
+            exit 2
+        else
+            echo "    Fail"
+            let "fail++"
+        fi
+    done
+}
+
+
+echo "----------------------------------------------------"
+echo "Checking source files for dead code and unused imports"
+echo "in following directories:"
+echo "$directories"
+echo "----------------------------------------------------"
+echo
+
+[ "$NOVENV" == "1" ] || prepare_venv || exit 1
+
+# checks for the whole directories
+for directory in $directories
+do
+    files=$(find "$directory" -path "$PYTHON_VENV_DIR" -prune -o -name '*.py' -print)
+
+    check_files "$files"
+done
+
+
+if [ $fail -eq 0 ]
+then
+    echo "All checks passed for $pass source files"
+else
+    let total=$pass+$fail
+    echo "$fail source files out of $total files seems to contain dead code and/or unused imports"
+    exit 1
+fi

--- a/hack/lint-python-code.sh
+++ b/hack/lint-python-code.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+source $(cat test-tmp-dir)/venv/bin/activate
+PYTHON_VENV_DIR=${VIRTUAL_ENV}
+
+failed=""
+CHECK_PYTHON=./hack
+source $CHECK_PYTHON/prepare-env.sh
+$CHECK_PYTHON/detect-common-errors.sh || failed="$failed\n - detect-common-errors"
+$CHECK_PYTHON/detect-dead-code.sh || failed="$failed\n - detect-dead-code"
+$CHECK_PYTHON/check-PEP8-style.sh || failed="$failed\n - check-PEP8-style"
+$CHECK_PYTHON/measure-cyclomatic-complexity.sh || failed="$failed\n - measure-cyclomatic-complexity"
+$CHECK_PYTHON/measure-maintainability-index.sh || failed="$failed\n - measure-maintainability-index"
+
+if [ ! -z "$failed" ]; then
+    echo -e "\nERROR: Following python checks FAILED:$failed\n"
+    exit 1
+else
+    echo -e "\nAll python checks PASSED"
+fi

--- a/hack/measure-cyclomatic-complexity.sh
+++ b/hack/measure-cyclomatic-complexity.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+. ./hack/prepare-env.sh
+
+[ "$NOVENV" == "1" ] || prepare_venv || exit 1
+
+echo "----------------------------------------------------"
+echo "Checking for cyclomatic complexity limits"
+echo "in the following directories:"
+echo "$directories"
+echo "----------------------------------------------------"
+echo
+
+echo "PYTHON_VENV_DIR=${PYTHON_VENV_DIR}"
+
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+for directory in ${SCRIPT_DIR}/.. $directories; do
+    pushd "$directory"
+    $PYTHON_VENV_DIR/bin/radon cc -s -a -i venv .
+    popd
+done

--- a/hack/measure-maintainability-index.sh
+++ b/hack/measure-maintainability-index.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+. ./hack/prepare-env.sh
+
+[ "$NOVENV" == "1" ] || prepare_venv || exit 1
+
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+
+for directory in ${SCRIPT_DIR}/.. $directories; do
+    pushd "$directory"
+    $PYTHON_VENV_DIR/bin/radon mi -s -i venv .
+    popd
+done

--- a/hack/prepare-env.sh
+++ b/hack/prepare-env.sh
@@ -1,0 +1,13 @@
+directories=${directories:-"features"}
+pass=0
+fail=0
+
+export PYTHON_VENV_DIR=${PYTHON_VENV_DIR:-venv}
+
+function prepare_venv() {
+    python3 -m venv "$PYTHON_VENV_DIR" && source "$PYTHON_VENV_DIR/bin/activate"
+    for req in $(find . -name 'requirements.txt'); do
+        python3 "$(which pip3)" install -q -r $req;
+    done
+    python3 "$(which pip3)" install -q -r $(dirname $0)/requirements.txt
+}

--- a/hack/requirements.txt
+++ b/hack/requirements.txt
@@ -1,0 +1,5 @@
+pydocstyle==2.1.1
+pyflakes==2.2.0
+vulture==2.1
+radon==4.3.1
+flake8_polyfill==1.0.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,3 @@
+[pycodestyle]
+max-line-length=120
+statistics = True


### PR DESCRIPTION
Lints can be run with hack/lint-python-code.sh.  We now check for a few things:
- pep8 consistency
- code complexity
- code maintainability
- dead code
- common errors

This also reformats the python step definitions to be in compliance with these checks.

Signed-off-by: Andy Sadler <ansadler@redhat.com>