### PR TITLE
ci: bump reference implementation to v0.2.0

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -34,7 +34,7 @@ jobs:
 
         # install the reference implementation
         kapp deploy -y -a cert-manager -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.yaml
-        kapp deploy -y -a servicebinding-runtime -f https://github.com/servicebinding/runtime/releases/download/v0.1.1/servicebinding-runtime-v0.1.1.yaml
+        kapp deploy -y -a servicebinding-runtime -f https://github.com/servicebinding/runtime/releases/download/v0.2.0/servicebinding-runtime-v0.2.0.yaml -f https://github.com/servicebinding/runtime/releases/download/v0.2.0/servicebinding-workloadresourcemappings-v0.2.0.yaml
     - name: Conformance tests
       run: .github/resources/run_ci.sh
   


### PR DESCRIPTION
v0.2.0 was released a while ago, we should use it in CI.

Signed-off-by: Andy Sadler <ansadler@redhat.com>