### PR TITLE
setup dependabot for dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  reviewers:
+  - servicebinding/conformance
+- package-ecosystem: pip
+  directory: "/features"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  reviewers:
+  - servicebinding/conformance
+- package-ecosystem: pip
+  directory: "/hack"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  reviewers:
+  - servicebinding/conformance
+- package-ecosystem: docker
+  directory: "/resources/apps/generic-test-app"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  reviewers:
+  - servicebinding/conformance


### PR DESCRIPTION
This tracks all of our dependencies:
- python dependencies specified in /features and /hack
- docker images under /resources/apps/generic-test-app
- github actions under /.github

Signed-off-by: Andy Sadler <ansadler@redhat.com>