### PR TITLE
Use behavex as a test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# conformance
+# Conformance testing
+
+This repository contains conformance tests for implementations of [the service binding specification][spec].
+
+# Running tests
+
+First, you'll need to set up the testing environment.  This can be done by
+running `./setup.sh`, which will pull the necessary dependencies.
+
+Next, make sure your implementation of the specification is available on your
+kubernetes cluster.  At the very least, you need to be serving
+`ServiceBindings` under the `servicebinding.io` namespace.  Your cluster will
+need to be available as the default context within `kubectl`.
+
+Once you've done that, you can invoke the test runner:
+```bash
+./run_tests.sh
+```
+
+## Test runner arguments
+
+The `./run_tests.sh` script accepts a few arguments, which can help test in certain environments:
+
+- `-j N`: runs acceptance tests with `N` runners.  Since this runs tests in
+  parallel without any namespace isolation, this can cause test instability in
+  some implementations.  If you see spurious failures, try testing with this
+  flag unset.  Defaults to 1.
+- `-n NAMESPACE`: run acceptance tests in `NAMESPACE`.  Defaults to
+  `servicebindings-cts`, which will be created if it doesn't exist.
+
+[spec]: https://github.com/servicebindings/spec

--- a/features/requirements.txt
+++ b/features/requirements.txt
@@ -1,4 +1,4 @@
-behave==1.2.6
+behavex==1.6.0
 polling2==0.5.0
 requests==2.31.0
 PyYAML==6.0

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,26 @@
 #!/usr/bin/env bash
 
+usage() {
+    echo "$0 usage:"
+    grep " .)\ #" $0 | sed -e "s/^\s\+\([a-z]\).*)\ # \(.*\)$/\t-\1: \2/g"
+    exit 0
+}
+
+while getopts ":j:n:h" arg; do
+    case $arg in
+        j) # set number of jobs to use to run tests (may cause test instability!)
+            jobs=${OPTARG}
+            ;;
+        n) # set the namespace to run tests in
+            TEST_NAMESPACE=${OPTARG}
+            ;;
+        h) # display help
+            usage
+            exit 0
+            ;;
+    esac
+done
+
 OUTPUT_DIR=test-output
 if [ -f test-tmp-dir ]; then
     OUTPUT_DIR=$(cat test-tmp-dir)
@@ -10,13 +31,20 @@ PYTHON_VENV_DIR="${OUTPUT_DIR}/venv"
 
 mkdir -p "${OUTPUT_DIR}"
 
-TEST_NAMESPACE="servicebindings-cts"
+if [ -z $TEST_NAMESPACE ]; then
+    TEST_NAMESPACE="servicebindings-cts"
+fi
+
 TEST_ACCEPTANCE_OUTPUT_DIR="${OUTPUT_DIR}"/results
 
 if [ $(kubectl get namespace ${TEST_NAMESPACE} > /dev/null; echo $?) -eq '0' ]; then
     kubectl delete namespace ${TEST_NAMESPACE}
 fi
 
+if [ -z $jobs ]; then
+    jobs=1
+fi
+
 echo "Running acceptance tests"
 
-TEST_NAMESPACE=${TEST_NAMESPACE} "${PYTHON_VENV_DIR}/bin/behave" --junit --junit-directory ${TEST_ACCEPTANCE_OUTPUT_DIR} --no-capture --no-capture-stderr features
+FEATURES_PATH=features TEST_NAMESPACE=${TEST_NAMESPACE} "${PYTHON_VENV_DIR}/bin/behavex" -o ${TEST_ACCEPTANCE_OUTPUT_DIR} --capture --capture-stderr --parallel-processes ${jobs} --parallel-scheme scenario


### PR DESCRIPTION
This allows us to run tests in parallel by adding a `-j N` flag to the test runner.  I've added a warning that it may cause test instability, though I haven't observed any issues with the reference implementation.

I've also used this as an excuse to flesh out the README a bit.  It's not perfect, but it's a step in the right direction.