### PR TITLE
Ensure test-app deployments have unique labels per scenario

### DIFF
--- a/features/steps/cluster.py
+++ b/features/steps/cluster.py
@@ -18,15 +18,15 @@ metadata:
   name: '{name}'
   namespace: {namespace}
   labels:
-    app: myapp
+    app: '{name}'
 spec:
   selector:
     matchLabels:
-      app: myapp
+      app: '{name}'
   template:
     metadata:
       labels:
-        app: myapp
+        app: '{name}'
     spec:
       containers:
       - name: myapp
@@ -196,8 +196,10 @@ spec:
                                                     namespace=namespace, bindingRoot=bindingRoot)
         if bindingRoot is not None:
             parsed = yaml.safe_load(formatted)
-            for obj in parsed['spec']['template']['spec']['containers']:
-                obj['env'] = [{'name': 'SERVICE_BINDING_ROOT', 'value': bindingRoot}]
+            for container in parsed['spec']['template']['spec']['containers']:
+                if 'env' not in container:
+                    container['env'] = list()
+                container['env'].append({'name': 'SERVICE_BINDING_ROOT', 'value': bindingRoot})
             formatted = yaml.dump(parsed)
         print(f'applying deployment: {formatted}')
         self.apply(formatted, namespace=namespace)


### PR DESCRIPTION
Previously, since every deployment of the generic test app had the same label, the services we would make as a part of testing would forward requests to any running deployment since they could match the label selector.  Make them unique, so that requests get forwarded to the correct pod.